### PR TITLE
UTF-8 fix

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -21,13 +21,15 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         if ($message->getContentType() === 'text/html' ||
             ($message->getContentType() === 'multipart/alternative' && $message->getBody())
         ) {
-            $converter->setHTML($message->getBody());
+            $html = '<?xml encoding="UTF-8">' . $message->getBody();
+            $converter->setHTML($html);
             $message->setBody($converter->convert());
         }
 
         foreach ($message->getChildren() as $part) {
             if (strpos($part->getContentType(), 'text/html') === 0) {
-                $converter->setHTML($part->getBody());
+                $html = '<?xml encoding="UTF-8">' . $part->getBody();
+                $converter->setHTML($html);
                 $part->setBody($converter->convert());
             }
         }


### PR DESCRIPTION
See http://php.net/manual/en/domdocument.loadhtml.php#95251 and http://php.net/manual/en/domdocument.loadhtml.php#74777
This actually took me some late-night hours to figure out.. I have a few hairs left...
Whether you need this fix probably depends on the version of libxml you have installed though... I got everything working allright on my local env but on production (packages lag behind a little) I got these horrendous encoding errors...