### PR TITLE
Introduce a config file to optionally strip style tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,14 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "illuminate/support": "~4.0|~5.0",
+        "php": ">=5.5.9",
+        "illuminate/support": "~5.0",
         "tijsverkoyen/css-to-inline-styles": "~1.2"
     },
     "require-dev" : {
         "jakub-onderka/php-parallel-lint": "0.8.*",
         "jakub-onderka/php-console-highlighter": "0.3.*",
+        "orchestra/testbench": "3.0.*",
         "phpmd/phpmd": "~1.5",
         "phpunit/phpunit": "~4.0",
         "satooshi/php-coveralls": "~0.7@dev",

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -2,10 +2,18 @@
 
 namespace Fedeisas\LaravelMailCssInliner;
 
+use Illuminate\Contracts\Config\Repository;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class CssInlinerPlugin implements \Swift_Events_SendListener
 {
+    protected $config;
+
+    public function __construct(Repository $config)
+    {
+        $this->config = $config;
+    }
+
     /**
      * @param Swift_Events_SendEvent $evt
      */
@@ -17,6 +25,10 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         $converter->setEncoding($message->getCharset());
         $converter->setUseInlineStylesBlock();
         $converter->setCleanup();
+
+        if($this->config->get('laravel-mail-css-inliner.strip-style-tags')) {
+            $converter->setStripOriginalStyleTags();
+        }
 
         if ($message->getContentType() === 'text/html' ||
             ($message->getContentType() === 'multipart/alternative' && $message->getBody())

--- a/src/LaravelMailCssInlinerServiceProvider.php
+++ b/src/LaravelMailCssInlinerServiceProvider.php
@@ -19,7 +19,11 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
+        $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin($this->app['config']));
+
+        $this->publishes([
+            __DIR__.'/config/laravel-mail-css-inliner.php' => config_path('laravel-mail-css-inliner.php'),
+        ]);
     }
 
     /**
@@ -29,7 +33,9 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Do nothing
+        $this->mergeConfigFrom(
+            __DIR__.'/config/laravel-mail-css-inliner.php', 'laravel-mail-css-inliner'
+        );
     }
 
     /**

--- a/src/config/laravel-mail-css-inliner.php
+++ b/src/config/laravel-mail-css-inliner.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'strip-style-tags' => false,
+];

--- a/tests/stubs/stripped-style-tags-html.stub
+++ b/tests/stubs/stripped-style-tags-html.stub
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head><style></style></head><body>
+        <div  style="height: 20px; width: 100px;">
+            text
+
+            <ul><li>
+                    Big list
+                </li>
+                <li  style="margin: 10px;">
+                    Small list
+                </li>
+            </ul></div>
+    </body></html>


### PR DESCRIPTION
As requested in #2, this commit introduces a config file with a `strip-style-tags` option that enables `setStripOriginalStyleTags()` on the converter.

Test case included.

Unfortunately this works only on Laravel 5, sorry L4 folks.