### PR TITLE
Fixing css inlining in emails with attachments

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -19,7 +19,8 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         $converter->setCleanup();
 
         if ($message->getContentType() === 'text/html' ||
-            ($message->getContentType() === 'multipart/alternative' && $message->getBody())
+            ($message->getContentType() === 'multipart/alternative' && $message->getBody()) ||
+            ($message->getContentType() === 'multipart/mixed' && $message->getBody())
         ) {
             $converter->setHTML($message->getBody());
             $message->setBody($converter->convert());


### PR DESCRIPTION
The content of emails with attachments wasn't being processed by the css inline parser. I've added `multipart/mixed` to the list of allowed content-types that will be processed to fix this issue.