### PR TITLE
Add configuration settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Into this:
 ## Installation
 Begin by installing this package through Composer. Edit your project's `composer.json` file to require `fedeisas/laravel-mail-css-inliner`.
 
-This package needs Laravel 4.x or Laravel 5.x
+This package needs Laravel 5.x
 ```json
 {
   "require": {
@@ -60,10 +60,16 @@ Next, update Composer from the Terminal:
 $ composer update
 ```
 
-Once this operation completes, the final step is to add the service provider. Open `app/config/app.php`, and add a new item to the providers array.
+Once this operation completes, you must add the service provider. Open `app/config/app.php`, and add a new item to the providers array.
 ```php
 'Fedeisas\LaravelMailCssInliner\LaravelMailCssInlinerServiceProvider',
 ```
+
+At this point the inliner should be already working with the default options. If you want to fine-tune these options, you can do so by publishing the configuration file:
+```bash
+$ php artisan vendor:publish --provider='Fedeisas\\LaravelMailCssInliner\\LaravelMailCssInlinerServiceProvider'
+```
+and changing the settings on the generated `config/css-inliner.php` file.
 
 ## Contributing
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4.0",
         "illuminate/support": "~5.0",
         "tijsverkoyen/css-to-inline-styles": "~1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "illuminate/support": "~4.0|~5.0",
+        "illuminate/support": "~5.0",
         "tijsverkoyen/css-to-inline-styles": "~1.2"
     },
     "require-dev" : {

--- a/config/css-inliner.php
+++ b/config/css-inliner.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Strip styles
+	|--------------------------------------------------------------------------
+	|
+	| Settings this to false prevents the inliner from removing the style
+	| definitions that have been inlined.
+	|
+	| Notice that media query styles are not inlined, and hence never
+	| stripped.
+	|
+	*/
+
+	'strip-styles' => true,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Remove classes
+	|--------------------------------------------------------------------------
+	|
+	| Settings this to false disables the removal of class attributes from
+	| your html elements (do not enable this if you use media queries)
+	|
+	*/
+
+	'strip-classes' => true,
+
+];

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -7,6 +7,19 @@ use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 class CssInlinerPlugin implements \Swift_Events_SendListener
 {
     /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @param array $options options defined in the configuration file.
+     */
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
      * @param Swift_Events_SendEvent $evt
      */
     public function beforeSendPerformed(\Swift_Events_SendEvent $evt)
@@ -14,10 +27,18 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         $message = $evt->getMessage();
 
         $converter = new CssToInlineStyles();
-        $converter->setUseInlineStylesBlock();
-        $converter->setStripOriginalStyleTags();
 
-        $converter->setCleanup();
+        // Always enabled because there is no way to specify an external style sheet
+        // when using this plugin
+        $converter->setUseInlineStylesBlock();
+
+        if ($this->options['strip-styles']) {
+            $converter->setStripOriginalStyleTags();
+        }
+
+        if ($this->options['strip-classes']) {
+            $converter->setCleanup();
+        }
 
         if ($message->getContentType() === 'text/html' ||
             ($message->getContentType() === 'multipart/alternative' && $message->getBody()) ||

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -27,18 +27,7 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         $message = $evt->getMessage();
 
         $converter = new CssToInlineStyles();
-
-        // Always enabled because there is no way to specify an external style sheet
-        // when using this plugin
-        $converter->setUseInlineStylesBlock();
-
-        if ($this->options['strip-styles']) {
-            $converter->setStripOriginalStyleTags();
-        }
-
-        if ($this->options['strip-classes']) {
-            $converter->setCleanup();
-        }
+        $this->applySettings($converter);
 
         if ($message->getContentType() === 'text/html' ||
             ($message->getContentType() === 'multipart/alternative' && $message->getBody()) ||
@@ -53,6 +42,26 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
                 $converter->setHTML($part->getBody());
                 $part->setBody($converter->convert());
             }
+        }
+    }
+
+    /**
+     * Applies the configuration settings.
+     *
+     * @param CssToInlineStyles $converter
+     */
+    private function applySettings(CssToInlineStyles $converter)
+    {
+        // Always enabled because there is no way to specify an external style sheet
+        // when using this plugin
+        $converter->setUseInlineStylesBlock();
+
+        if ($this->options['strip-styles']) {
+            $converter->setStripOriginalStyleTags();
+        }
+
+        if ($this->options['strip-classes']) {
+            $converter->setCleanup();
         }
     }
 

--- a/src/LaravelMailCssInlinerServiceProvider.php
+++ b/src/LaravelMailCssInlinerServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Fedeisas\LaravelMailCssInliner;
 
 use Illuminate\Support\ServiceProvider;
+use Swift_Mailer;
 
 class LaravelMailCssInlinerServiceProvider extends ServiceProvider
 {
@@ -19,7 +20,9 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['mailer']->getSwiftMailer()->registerPlugin(new CssInlinerPlugin());
+        $this->publishes([
+            __DIR__.'/../config/css-inliner.php' => config_path('css-inliner.php'),
+        ], 'config');
     }
 
     /**
@@ -29,16 +32,19 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Do nothing
-    }
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/css-inliner.php', 'css-inliner'
+        );
 
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return array();
+        $this->app->singleton('Fedeisas\LaravelMailCssInliner\CssInlinerPlugin', function($app) {
+            $options = $app['config']->get('css-inliner');
+            return new CssInlinerPlugin($options);
+        });
+
+        $this->app->extend('swift.mailer', function(Swift_Mailer $swiftMailer, $app) {
+            $inlinerPlugin = $app->make('Fedeisas\LaravelMailCssInliner\CssInlinerPlugin');
+            $swiftMailer->registerPlugin($inlinerPlugin);
+            return $swiftMailer;
+        });
     }
 }

--- a/src/LaravelMailCssInlinerServiceProvider.php
+++ b/src/LaravelMailCssInlinerServiceProvider.php
@@ -32,16 +32,14 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/css-inliner.php', 'css-inliner'
-        );
+        $this->mergeConfigFrom(__DIR__.'/../config/css-inliner.php', 'css-inliner');
 
-        $this->app->singleton('Fedeisas\LaravelMailCssInliner\CssInlinerPlugin', function($app) {
+        $this->app->singleton('Fedeisas\LaravelMailCssInliner\CssInlinerPlugin', function ($app) {
             $options = $app['config']->get('css-inliner');
             return new CssInlinerPlugin($options);
         });
 
-        $this->app->extend('swift.mailer', function(Swift_Mailer $swiftMailer, $app) {
+        $this->app->extend('swift.mailer', function (Swift_Mailer $swiftMailer, $app) {
             $inlinerPlugin = $app->make('Fedeisas\LaravelMailCssInliner\CssInlinerPlugin');
             $swiftMailer->registerPlugin($inlinerPlugin);
             return $swiftMailer;

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -8,13 +8,16 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
 
     protected $options;
 
+    protected static $stubDefinitions = array(
+        'plain-text', 'original-html', 'converted-html', 'converted-html-with-classes',
+        'converted-html-with-styles'
+    );
+
     public function setUp()
     {
-        $this->stubs['plain-text'] = file_get_contents(__DIR__.'/stubs/plain-text.stub');
-        $this->stubs['original-html'] = file_get_contents(__DIR__.'/stubs/original-html.stub');
-        $this->stubs['converted-html'] = file_get_contents(__DIR__.'/stubs/converted-html.stub');
-        $this->stubs['converted-html-with-classes'] = file_get_contents(__DIR__.'/stubs/converted-html-with-classes.stub');
-        $this->stubs['converted-html-with-styles'] = file_get_contents(__DIR__.'/stubs/converted-html-with-styles.stub');
+        foreach (self::$stubDefinitions as $stub) {
+            $this->stubs[$stub] = file_get_contents(__DIR__.'/stubs/'.$stub.'.stub');
+        }
 
         $this->options = require(__DIR__.'/../config/css-inliner.php');
     }
@@ -144,5 +147,4 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->stubs['converted-html'], $children[0]->getBody());
     }
-
 }

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -4,14 +4,19 @@ use Fedeisas\LaravelMailCssInliner\CssInlinerPlugin;
 
 class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
 {
-
     protected $stubs;
+
+    protected $options;
 
     public function setUp()
     {
         $this->stubs['plain-text'] = file_get_contents(__DIR__.'/stubs/plain-text.stub');
         $this->stubs['original-html'] = file_get_contents(__DIR__.'/stubs/original-html.stub');
         $this->stubs['converted-html'] = file_get_contents(__DIR__.'/stubs/converted-html.stub');
+        $this->stubs['converted-html-with-classes'] = file_get_contents(__DIR__.'/stubs/converted-html-with-classes.stub');
+        $this->stubs['converted-html-with-styles'] = file_get_contents(__DIR__.'/stubs/converted-html-with-styles.stub');
+
+        $this->options = require(__DIR__.'/../config/css-inliner.php');
     }
 
     /** @test **/
@@ -19,7 +24,7 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     {
         $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
 
-        $mailer->registerPlugin(new CssInlinerPlugin());
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
 
         $message = Swift_Message::newInstance();
 
@@ -34,11 +39,53 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test **/
+    public function itShouldConvertHtmlBodyKeepingClasses()
+    {
+        $this->options['strip-classes'] = false;
+
+        $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
+
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
+
+        $message = Swift_Message::newInstance();
+
+        $message->setFrom('test@example.com');
+        $message->setTo('test2@example.com');
+        $message->setSubject('Test');
+        $message->setBody($this->stubs['original-html'], 'text/html');
+
+        $mailer->send($message);
+
+        $this->assertEquals($this->stubs['converted-html-with-classes'], $message->getBody());
+    }
+
+    /** @test **/
+    public function itShouldConvertHtmlBodyKeepingStyles()
+    {
+        $this->options['strip-styles'] = false;
+
+        $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
+
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
+
+        $message = Swift_Message::newInstance();
+
+        $message->setFrom('test@example.com');
+        $message->setTo('test2@example.com');
+        $message->setSubject('Test');
+        $message->setBody($this->stubs['original-html'], 'text/html');
+
+        $mailer->send($message);
+
+        $this->assertEquals($this->stubs['converted-html-with-styles'], $message->getBody());
+    }
+
+    /** @test **/
     public function itShouldConvertHtmlBodyAndTextParts()
     {
         $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
 
-        $mailer->registerPlugin(new CssInlinerPlugin());
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
 
         $message = Swift_Message::newInstance();
 
@@ -61,7 +108,7 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     {
         $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
 
-        $mailer->registerPlugin(new CssInlinerPlugin());
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
 
         $message = Swift_Message::newInstance();
 
@@ -82,7 +129,7 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     {
         $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
 
-        $mailer->registerPlugin(new CssInlinerPlugin());
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
 
         $message = Swift_Message::newInstance();
 
@@ -97,4 +144,5 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->stubs['converted-html'], $children[0]->getBody());
     }
+
 }

--- a/tests/stubs/converted-html-with-classes.stub
+++ b/tests/stubs/converted-html-with-classes.stub
@@ -1,0 +1,13 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head><style></style></head><body>
+        <div class="block" style="height: 20px; width: 100px;">
+            text
+
+            <ul><li>
+                    Big list
+                </li>
+                <li class="small" style="margin: 10px;">
+                    Small list
+                </li>
+            </ul></div>
+    </body></html>

--- a/tests/stubs/converted-html-with-styles.stub
+++ b/tests/stubs/converted-html-with-styles.stub
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head><style>
+            .block {
+                width: 100px;
+                height: 20px;
+            }
+            div.block ul li.small {
+                margin: 10px;
+            }
+        </style></head><body>
+        <div style="height: 20px; width: 100px;">
+            text
+
+            <ul><li>
+                    Big list
+                </li>
+                <li style="margin: 10px;">
+                    Small list
+                </li>
+            </ul></div>
+    </body></html>


### PR DESCRIPTION
Adds a new configuration file that allows the package user to tune the underlying `CssToInlineStyles` settings.

In addition, this commit delays the plugin's instantitation until the mailer is actually used, preventing a forced instantiation of the whole laravel's mail subsystem for every request.

# Usage
First you need to publish the configuraton file:
```
php artisan vendor:publish --provider='Fedeisas\\LaravelMailCssInliner\\LaravelMailCssInlinerServiceProvider'
```
This will generate a `config/css-inliner.php` configuration file. Change the options there and the plugin's behavior will change accordingly.

# Caveats
Unfortunately, this comes with two caveats.

Firstly, dropped support for Laravel 4. I don't know how to publish and load a default configuration file in a manner that is compatible between L4 and L5.

Secondly, it must be noted that the plugin is registered to swiftmailer every time the mailer gets resolved. This is currently not a problem because:

1.  The plugin's instance is always the same
2. SwiftMailer doesn't register the same plugin instance multiple times (it skips the registration if the plugin is already registered)