### PR TITLE
Load css from link tag in the html

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ and changing the settings on the generated `config/css-inliner.php` file.
 ```bash
 $ composer install
 $ ./vendor/bin/phpunit
+$ ./vendor/bin/phpcs --standard=phpcs.xml ./src/
+$ ./vendor/bin/phpcs --standard=phpcs.xml ./tests/;
 ```
 In addition to a full test suite, there is Travis integration.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The goal of this package is to automate the process of inlining that CSS before 
 ## How?
 Using a wonderful [CSS inliner package](https://github.com/tijsverkoyen/CssToInlineStyles) wraped in a SwiftMailer plugin and served as a Service Provider it justs works without any configuration.
 
-Turns:
+Turns style tag:
 ```html
 <html>
     <head>
@@ -25,6 +25,17 @@ Turns:
                 color: #000;
             }
         </style>
+    </head>
+    <body>
+        <h1>Hey you</h1>
+    </body>
+</html>
+```
+Or the link tag:
+```html
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="./tests/css/test.css">
     </head>
     <body>
         <h1>Hey you</h1>

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -62,7 +62,8 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
      * Load the options
      * @param  array $options Options array
      */
-    public function loadOptions($options){
+    public function loadOptions($options)
+    {
         if (isset($options['css-files']) && count($options['css-files']) > 0) {
             $this->css = '';
             foreach ($options['css-files'] as $file) {
@@ -80,24 +81,25 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
      * 
      * @return string $message The message
      */
-    public function loadCssFilesFromLinks($message){
+    public function loadCssFilesFromLinks($message)
+    {
         $dom = new \DOMDocument();
         $dom->loadHTML($message);
         $link_tags = $dom->getElementsByTagName('link');
 
-        if($link_tags->length > 0){
+        if ($link_tags->length > 0) {
             do {
-                if($link_tags->item(0)->getAttribute('rel') == "stylesheet"){
+                if ($link_tags->item(0)->getAttribute('rel') == "stylesheet") {
                     $options['css-files'][] = $link_tags->item(0)->getAttribute('href');
 
                     // remove the link node
                     $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
                 }
-            } while($link_tags->length > 0);
+            } while ($link_tags->length > 0);
 
-            if(isset($options)){
+            if (isset($options)) {
                 // reload the options
-                $this->loadOptions($options);               
+                $this->loadOptions($options);
             }
 
             return $dom->saveHTML();

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -9,8 +9,8 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     protected $options;
 
     protected static $stubDefinitions = array(
-        'plain-text', 'original-html', 'original-html-with-css','converted-html',
-        'converted-html-with-css'
+        'plain-text', 'original-html', 'original-html-with-css', 'original-html-with-link-css', 'original-html-with-links-css', 'converted-html',
+        'converted-html-with-css', 'converted-html-with-links-css'
     );
 
     public function setUp()
@@ -124,5 +124,45 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
         $children = $message->getChildren();
 
         $this->assertEquals($this->stubs['converted-html'], $children[0]->getBody());
+    }
+
+    /** @test **/
+    public function itShouldConvertHtmlBodyWithLinkCss()
+    {
+        $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
+
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
+
+        $message = Swift_Message::newInstance();
+
+        $message->setFrom('test@example.com');
+        $message->setTo('test2@example.com');
+        $message->setSubject('Test');
+
+        $message->setBody($this->stubs['original-html-with-link-css'], 'text/html');
+
+        $mailer->send($message);
+
+        $this->assertEquals($this->stubs['converted-html-with-css'], $message->getBody());
+    }
+
+    /** @test **/
+    public function itShouldConvertHtmlBodyWithLinksCss()
+    {
+        $mailer = Swift_Mailer::newInstance(Swift_NullTransport::newInstance());
+
+        $mailer->registerPlugin(new CssInlinerPlugin($this->options));
+
+        $message = Swift_Message::newInstance();
+
+        $message->setFrom('test@example.com');
+        $message->setTo('test2@example.com');
+        $message->setSubject('Test');
+
+        $message->setBody($this->stubs['original-html-with-links-css'], 'text/html');
+
+        $mailer->send($message);
+
+        $this->assertEquals($this->stubs['converted-html-with-links-css'], $message->getBody());
     }
 }

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -9,8 +9,9 @@ class CssInlinerPluginTest extends PHPUnit_Framework_TestCase
     protected $options;
 
     protected static $stubDefinitions = array(
-        'plain-text', 'original-html', 'original-html-with-css', 'original-html-with-link-css', 'original-html-with-links-css', 'converted-html',
-        'converted-html-with-css', 'converted-html-with-links-css'
+        'plain-text', 'original-html', 'original-html-with-css',
+        'original-html-with-link-css', 'original-html-with-links-css',
+        'converted-html', 'converted-html-with-css', 'converted-html-with-links-css'
     );
 
     public function setUp()

--- a/tests/css/test2.css
+++ b/tests/css/test2.css
@@ -1,0 +1,3 @@
+body {
+	background-color: red;
+}

--- a/tests/css/test2.css
+++ b/tests/css/test2.css
@@ -1,3 +1,3 @@
 body {
-	background-color: red;
+   background-color: red;
 }

--- a/tests/stubs/converted-html-with-links-css.stub
+++ b/tests/stubs/converted-html-with-links-css.stub
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html>
+<head></head>
+<body style="background-color: red;">
+        <div class="pixels-10" style="width: 10px;">
+            text
+
+            <ul>
+<li>
+                    Big list
+                </li>
+                <li>
+                    Small list
+                </li>
+            </ul>
+</div>
+    </body>
+</html>

--- a/tests/stubs/original-html-with-link-css.stub
+++ b/tests/stubs/original-html-with-link-css.stub
@@ -1,0 +1,20 @@
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="./tests/css/test.css">
+    </head>
+    <body>
+        <div class="pixels-10">
+            text
+
+            <ul>
+                <li>
+                    Big list
+                </li>
+                <li>
+                    Small list
+                </li>
+            </ul>
+        </div>
+    </body>
+</html>
+

--- a/tests/stubs/original-html-with-links-css.stub
+++ b/tests/stubs/original-html-with-links-css.stub
@@ -1,0 +1,21 @@
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="./tests/css/test.css">
+        <link rel="stylesheet" type="text/css" href="./tests/css/test2.css">
+    </head>
+    <body>
+        <div class="pixels-10">
+            text
+
+            <ul>
+                <li>
+                    Big list
+                </li>
+                <li>
+                    Small list
+                </li>
+            </ul>
+        </div>
+    </body>
+</html>
+


### PR DESCRIPTION
While working with this repo I noticed that despite the `<link>` tag being mentioned the code did not load the stylesheet. I figured out how you can do it by publishing the settings and adding the files manually in the array.

- This pull request extracts the loading of the options to a method, so it can be reusable
- Read the css link tags from the source code of the email and loads the css to be inlined

I don't know if you want this functionality to be optional via an option setting.