### PR TITLE
Avoid problem with HTML with fault

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -84,7 +84,13 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
     public function loadCssFilesFromLinks($message)
     {
         $dom = new \DOMDocument();
+        // set error level
+        $internalErrors = libxml_use_internal_errors(true);
+        
         $dom->loadHTML($message);
+        
+        // Restore error level
+        libxml_use_internal_errors($internalErrors);
         $link_tags = $dom->getElementsByTagName('link');
 
         if ($link_tags->length > 0) {


### PR DESCRIPTION
This disable the warnings when loading the HTML to avoid the "htmlParseEntityRef: expecting ';'" that can happen when the HTML is not following the RFC to the line but still valid.

https://stackoverflow.com/questions/1685277/warning-domdocumentloadhtml-htmlparseentityref-expecting-in-entity