### PR TITLE
Add Laravel 5.5 Package Auto Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,12 @@
         "psr-4": {
             "Fedeisas\\LaravelMailCssInliner\\": "src/"
         }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Fedeisas\\LaravelMailCssInliner\\LaravelMailCssInlinerServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Add package auto-discovery. Tested on Laravel 5.5.

Based on:
  - https://github.com/fideloper/TrustedProxy/pull/78/files
  - https://github.com/barryvdh/laravel-debugbar/pull/643/files