### PR TITLE
Fixes infinite cycle

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -97,10 +97,10 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
             do {
                 if ($link_tags->item(0)->getAttribute('rel') == "stylesheet") {
                     $options['css-files'][] = $link_tags->item(0)->getAttribute('href');
-
-                    // remove the link node
-                    $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
                 }
+                
+                // remove the link node in any situation, otherwise we got infinite cycle...
+                $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
             } while ($link_tags->length > 0);
 
             if (isset($options)) {

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -94,14 +94,17 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
         $link_tags = $dom->getElementsByTagName('link');
 
         if ($link_tags->length > 0) {
+            $length = $link_tags->length;
             do {
                 if ($link_tags->item(0)->getAttribute('rel') == "stylesheet") {
                     $options['css-files'][] = $link_tags->item(0)->getAttribute('href');
+
+                    // remove the link node in any situation, otherwise we got infinite cycle...
+                    $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
                 }
-                
-                // remove the link node in any situation, otherwise we got infinite cycle...
-                $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
-            } while ($link_tags->length > 0);
+
+                $length--;
+            } while ($length >= 0);
 
             if (isset($options)) {
                 // reload the options

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -99,7 +99,7 @@ class CssInlinerPlugin implements \Swift_Events_SendListener
                 if ($link_tags->item(0)->getAttribute('rel') == "stylesheet") {
                     $options['css-files'][] = $link_tags->item(0)->getAttribute('href');
 
-                    // remove the link node in any situation, otherwise we got infinite cycle...
+                    // remove the link node
                     $link_tags->item(0)->parentNode->removeChild($link_tags->item(0));
                 }
 


### PR DESCRIPTION
when using non-stylesheet <link> tag.

For example inserting Go-to-action that contains
```
<link itemprop="target" href="https://watch-movies.com/watch?movieId=abc123"/>
```

https://developers.google.com/gmail/markup/reference/go-to-action