### PR TITLE
Switch to afterResolving when registering service provider

### DIFF
--- a/src/LaravelMailCssInlinerServiceProvider.php
+++ b/src/LaravelMailCssInlinerServiceProvider.php
@@ -30,7 +30,7 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
             return new CssInlinerPlugin($app['config']->get('css-inliner'));
         });
 
-        $this->app->extend('mail.manager', function (MailManager $mailManager) {
+        $this->app->afterResolving('mail.manager', function (MailManager $mailManager) {
             $mailManager->getSwiftMailer()->registerPlugin($this->app->make(CssInlinerPlugin::class));
             return $mailManager;
         });


### PR DESCRIPTION
This helps fix the conflict with therobfonz/laravel-mandrill-driver on Laravel 7.
They will also need to fix their ServiceProvider before the conflict is fully resolved.
#84 