### PR TITLE
Fix inlining of css in mail with attachments

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -8,6 +8,7 @@ use Symfony\Component\Mime\Message;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
+use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\TextPart;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -85,8 +86,9 @@ class CssInlinerPlugin
 
         if ($body instanceof TextPart) {
             $message->setBody($this->processPart($body));
-        } elseif ($body instanceof AlternativePart) {
-            $message->setBody(new AlternativePart(
+        } elseif ($body instanceof AlternativePart || $body instanceof MixedPart) {
+            $part_type = get_class($body);
+            $message->setBody(new $part_type(
                 ...array_map(
                     fn (AbstractPart $part) => $this->processPart($part),
                     $body->getParts()

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -7,6 +7,7 @@ use Illuminate\Mail\Events\MessageSending;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\AbstractMultipartPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\TextPart;
@@ -51,6 +52,15 @@ class CssInlinerPlugin
     {
         if ($part instanceof TextPart && $part->getMediaType() === 'text' && $part->getMediaSubtype() === 'html') {
             return $this->processHtmlTextPart($part);
+        } else if ($part instanceof AbstractMultipartPart) {
+            $part_class = get_class($part);
+            $parts = [];
+
+            foreach ($part->getParts() as $childPart) {
+                $parts[] = $this->processPart($childPart);
+            }
+
+            return new $part_class(...$parts);
         }
 
         return $part;

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -4,7 +4,7 @@ namespace Fedeisas\LaravelMailCssInliner;
 
 use DOMDocument;
 use Illuminate\Mail\Events\MessageSending;
-use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
@@ -29,22 +29,22 @@ class CssInlinerPlugin
     {
         $message = $event->message;
 
-        if (!$message instanceof Message) {
+        if (!$message instanceof Email) {
             return;
         }
 
-        $this->handleSymfonyMessage($message);
+        $this->handleSymfonyEmail($message);
     }
 
     public function handleSymfonyEvent(MessageEvent $event): void
     {
         $message = $event->getMessage();
 
-        if (!$message instanceof Message) {
+        if (!$message instanceof Email) {
             return;
         }
 
-        $this->handleSymfonyMessage($message);
+        $this->handleSymfonyEmail($message);
     }
 
     private function processPart(AbstractPart $part): AbstractPart
@@ -76,7 +76,7 @@ class CssInlinerPlugin
         return new TextPart($bodyString, $part->getPreparedHeaders()->getHeaderParameter('Content-Type', 'charset') ?: 'utf-8', 'html');
     }
 
-    private function handleSymfonyMessage(Message $message): void
+    private function handleSymfonyEmail(Email $message): void
     {
         $body = $message->getBody();
 

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -162,12 +162,15 @@ class CssInlinerPluginTest extends TestCase
             Transport::fromDsn('null://default', $dispatcher)
         );
 
+        // Check if the message is valid (has to, cc and bcc set). If not, we create a valid message.
         try {
-            $mailer->send(
-                $message->to('test2@example.com')
-                        ->from('test@example.com')
-                        ->subject('Test')
-            );
+            $message->ensureValidity();
+        } catch (LogicException) {
+            $message = $this->createMessageToSend($message);
+        }
+
+        try {
+            $mailer->send($message);
         } catch (TransportExceptionInterface) {
             // We are not really expecting anything to happen here considering it's a `NullTransport` we are using :)
         }
@@ -177,5 +180,18 @@ class CssInlinerPluginTest extends TestCase
         }
 
         return $processedMessage;
+    }
+
+    private function createMessageToSend(Email $message, string $attachmentPath = null): Email
+    {
+        $message = $message->to('test2@example.com')
+                    ->from('test@example.com')
+                    ->subject('Test');
+
+        if (! is_null($attachmentPath)) {
+            $message = $message->attachFromPath($attachmentPath);
+        }
+
+        return $message;
     }
 }

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -125,7 +125,7 @@ class CssInlinerPluginTest extends TestCase
 
         if ($body instanceof TextPart) {
             $actual = $body->getBody();
-        } elseif ($body instanceof AlternativePart) {
+        } elseif ($body instanceof AlternativePart || $body instanceof MixedPart) {
             $actual = (new Collection($body->getParts()))->first(
                 static fn ($part) => $part instanceof TextPart && $part->getMediaType() === 'text' && $part->getMediaSubtype() === $mediaSubType
             )->getBody();


### PR DESCRIPTION
This PR fixes an issue where css was not inlined anymore when the mail had an attachment.

I also tried to make sure the processed mail has the same structure as the original message with regards to the MIME types of the different parts. Having a different structure could cause issues displaying the attachment in some mail clients. (mentioned [here](https://github.com/fedeisas/laravel-mail-css-inliner/pull/178#issuecomment-1202704541))
Some tests have been added to validate this behavior.

Fixes #175