### PR TITLE
added secure check to enable or disable ssl check for get_file_contents

### DIFF
--- a/config/css-inliner.php
+++ b/config/css-inliner.php
@@ -15,4 +15,15 @@ return [
 
     'css-files' => [],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Secure
+    |--------------------------------------------------------------------------
+    |
+    | By setting this option to true, you let the package only allow to
+    | retrieve contents from the url if it is HTTPS and if it has a valid
+    | SSL certificate. Setting this option to false will disable this check.
+    |
+    */
+    'secure' => false
 ];

--- a/config/css-inliner.php
+++ b/config/css-inliner.php
@@ -25,5 +25,5 @@ return [
     | SSL certificate. Setting this option to false will disable this check.
     |
     */
-    'secure' => false
+    'secure' => true
 ];

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -16,9 +16,12 @@ class CssInlinerPlugin
     private CssToInlineStyles $converter;
 
     private string $cssToAlwaysInclude;
+    private bool   $secure;
 
-    public function __construct(array $filesToInline = [], CssToInlineStyles $converter = null)
+    public function __construct(array $filesToInline = [], bool $secure = true, CssToInlineStyles $converter = null)
     {
+        $this->secure = $secure;
+
         $this->cssToAlwaysInclude = $this->loadCssFromFiles($filesToInline);
 
         $this->converter = $converter ?? new CssToInlineStyles;
@@ -60,7 +63,19 @@ class CssInlinerPlugin
         $css = '';
 
         foreach ($cssFiles as $file) {
-            $css .= file_get_contents($file);
+            $css .= file_get_contents(
+                $file,
+                false,
+                stream_context_create(
+                    [
+                        'ssl' =>
+                            [
+                                'verify_peer'      => $this->secure,
+                                'verify_peer_name' => $this->secure,
+                            ],
+                    ]
+                )
+            );
         }
 
         return $css;

--- a/src/LaravelMailCssInlinerServiceProvider.php
+++ b/src/LaravelMailCssInlinerServiceProvider.php
@@ -26,9 +26,14 @@ class LaravelMailCssInlinerServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/css-inliner.php', 'css-files');
+        $this->mergeConfigFrom(__DIR__ . '/../config/css-inliner.php', 'secure');
 
         $this->app->singleton(CssInlinerPlugin::class, function ($app) {
-            return new CssInlinerPlugin($app['config']->get('css-inliner.css-files', []));
+            $config = $app['config'];
+            return new CssInlinerPlugin(
+                $config->get('css-inliner.css-files', []),
+                $config->get('css-inliner.secure')
+            );
         });
 
         Event::listen(MessageSending::class, CssInlinerPlugin::class);


### PR DESCRIPTION
Resolves https://github.com/fedeisas/laravel-mail-css-inliner/issues/255
When using valet the get_file_contents always checks ssl. The secure config setting is always set to true, except when the developer modifies the variable.