### PR TITLE
Fix CSS Inlining when using embedded image using Laravel 10 or 9.

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -96,7 +96,7 @@ class CssInlinerPlugin
 
         if ($body instanceof TextPart) {
             $message->setBody($this->processPart($body));
-        } elseif ($body instanceof AlternativePart || $body instanceof MixedPart) {
+        } elseif ($body instanceof AbstractMultipartPart || $body instanceof AlternativePart || $body instanceof MixedPart) {
             $part_type = get_class($body);
             $message->setBody(new $part_type(
                 ...array_map(

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -96,7 +96,7 @@ class CssInlinerPlugin
 
         if ($body instanceof TextPart) {
             $message->setBody($this->processPart($body));
-        } elseif ($body instanceof AbstractMultipartPart || $body instanceof AlternativePart || $body instanceof MixedPart) {
+        } elseif ($body instanceof AbstractMultipartPart) {
             $part_type = get_class($body);
             $message->setBody(new $part_type(
                 ...array_map(


### PR DESCRIPTION
Added the suggested changes as seen here: https://github.com/fedeisas/laravel-mail-css-inliner/issues/311

`AbstractMultipartPart` is a parent of both of the existing conditions, so it shouldn't change the functionality.

Tests pass.