### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             name: 'PHP 8.2 with lowest stable deps'
             composer_update_flags: '--prefer-lowest --prefer-stable'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -50,7 +50,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -78,6 +78,6 @@ jobs:
   composer-normalize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Composer normalize
         uses: localheinz/composer-normalize-action@0.5.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: CI
 
 on:
-    push:
-        branches: [ master ]
-    pull_request:
-        branches: [ master ]
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,13 @@ jobs:
             allow_fail: false
             name: 'PHP 8.2 with lowest stable deps'
             composer_update_flags: '--prefer-lowest --prefer-stable'
+          - php: 8.3
+            allow_fail: false
+            name: 'PHP 8.3 with latest deps'
+          - php: 8.3
+            allow_fail: false
+            name: 'PHP 8.3 with lowest stable deps'
+            composer_update_flags: '--prefer-lowest --prefer-stable'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "tijsverkoyen/css-to-inline-styles": "~2.2"
     },
     "require-dev": {
-        "enlightn/security-checker": "^1.10",
+        "enlightn/security-checker": "^1.10 || ^2.0",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
This PR fixes the GitHub workflow file (`main.yml`) in order to reinstate the running of the workflow when a PR is created.
Also see https://github.com/fedeisas/laravel-mail-css-inliner/actions/runs/6221782869 for the warnings from the last time the workflow was executed.

In order to correct the workflow this PR does
- Correct all indentations to 2 spaces
- Switch to version 4 of Github Actions for `checkout` and `cache`. See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- Replace the deprecated `set-output` with environment variables. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/