### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Laravel Mail CSS Inliner
 ========================
 
-![](https://github.com/fedeisas/laravel-mail-css-inliner/workflows/CI/badge.svg)
+[![CI status](https://github.com/fedeisas/laravel-mail-css-inliner/actions/workflows/main.yml/badge.svg)](https://github.com/fedeisas/laravel-mail-css-inliner/actions)
 [![Dependabot Status](https://img.shields.io/badge/dependabot-active-brightgreen?logo=dependabot)](https://dependabot.com)
 [![Latest Stable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
 [![Latest Unstable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v/unstable)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ Laravel Mail CSS Inliner
 ========================
 
 ![](https://github.com/fedeisas/laravel-mail-css-inliner/workflows/CI/badge.svg)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=fedeisas/laravel-mail-css-inliner&identifier=16568832)](https://dependabot.com)
-[![Latest Stable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v/stable.png)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
-[![Latest Unstable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v/unstable.png)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
-[![Total Downloads](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/downloads.png)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
-[![License](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/license.png)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
+[![Dependabot Status](https://img.shields.io/badge/dependabot-active-brightgreen?logo=dependabot)](https://dependabot.com)
+[![Latest Stable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
+[![Latest Unstable Version](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/v/unstable)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
+[![Total Downloads](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/downloads)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
+[![License](https://poser.pugx.org/fedeisas/laravel-mail-css-inliner/license)](https://packagist.org/packages/fedeisas/laravel-mail-css-inliner)
 
 ## Why?
 Most email clients won't render CSS (on a `<link>` or a `<style>`). The solution is inline your CSS directly on the HTML. Doing this by hand easily turns into unmantainable templates.


### PR DESCRIPTION
fixed badges to show them properly

Dependabot badges are broken according to this:
https://github.com/dependabot/dependabot-core/issues/1912https://github.com/dependabot/dependabot-core/issues/1912

so, I replace it with static badge

Fixes #331 
