### PR TITLE
fix typo & php 8.4 deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Laravel Mail CSS Inliner
 Most email clients won't render CSS (on a `<link>` or a `<style>`). The solution is inline your CSS directly on the HTML. Doing this by hand easily turns into unmantainable templates.
 The goal of this package is to automate the process of inlining that CSS before sending the emails.
 
-## Installation and compatability
+## Installation and compatibility
 
 Starting with version 5 this package requires PHP 8.0 and Laravel 9.0 or higher.
 

--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -19,7 +19,7 @@ class CssInlinerPlugin
 
     private string $cssToAlwaysInclude;
 
-    public function __construct(array $filesToInline = [], CssToInlineStyles $converter = null)
+    public function __construct(array $filesToInline = [], ?CssToInlineStyles $converter = null)
     {
         $this->cssToAlwaysInclude = $this->loadCssFromFiles($filesToInline);
 


### PR DESCRIPTION
This PR fixes a deprecation warning in php8.4 
`PHP Deprecated:  Fedeisas\LaravelMailCssInliner\CssInlinerPlugin::__construct(): Implicitly marking parameter $converter as nullable is deprecated, the explicit nullable type must be used instead`

+ a small typo