### PR TITLE
Add support for Symfony Email HTML body

### DIFF
--- a/src/CssInlinerPlugin.php
+++ b/src/CssInlinerPlugin.php
@@ -105,6 +105,13 @@ class CssInlinerPlugin
                 )
             ));
         }
+
+        if (!empty($message->getHtmlBody())) {
+            $htmlBody = new TextPart($message->getHtmlBody());
+            $htmlBody = $this->processHtmlTextPart($htmlBody)->getBody();
+
+            $message->html($htmlBody);
+        }
     }
 
     private function extractCssFilesFromMailBody(string $message): array

--- a/tests/CssInlinerPluginTest.php
+++ b/tests/CssInlinerPluginTest.php
@@ -234,6 +234,14 @@ class CssInlinerPluginTest extends TestCase
         }
 
         $this->assertEquals($this->stubs[$stub], $this->cleanupHtmlStringForComparison($actual));
+
+        if ($mediaSubType === 'html') {
+            $htmlBody = $message->getHtmlBody();
+
+            if (!empty($htmlBody)) {
+                $this->assertEquals($this->stubs[$stub], $this->cleanupHtmlStringForComparison($htmlBody));
+            }
+        }
     }
 
     private function assertSameMessageStructure(Email $expected, Email $actual)


### PR DESCRIPTION
The `symfony/postmark-mailer` package, a popular mail driver for Laravel projects, has an API based transport. It passes both a plain text and HTML message to their API. These are extracted as string from the `\Symfony\Component\Mime\Email` instance via the `getTextBody()` and most importantly `getHtmlBody()` - which returns the `$html` property.

Currently, this package doesn't update the content of that property during the inlining process.

This PR attempts to resolve that by checking to see if a HTML Body exists on the message, and if it does, also run that through the inlining process, before setting it back by calling the `html()` method (_inspired by previous attempts at resoling this issue - see references below)_.

Additional test assertions have been added.

_This issue has been discussed previously in #261, #305 and #308 a few years ago, but nothing was ever merged due to a lack of tests by the previous author._