### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "ext-dom": "*",
         "illuminate/mail": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "paragonie/random_compat": "~2.0 || ~9.99",
         "tijsverkoyen/css-to-inline-styles": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ~2.0 || ~9.99`, but also `php: ^8.0.2`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?